### PR TITLE
Fix if no sdcard path will be crashed

### DIFF
--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/fragments/ChooserDialogFragment.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/fragments/ChooserDialogFragment.java
@@ -232,7 +232,7 @@ public class ChooserDialogFragment extends android.app.DialogFragment {
         storagesList = new ArrayList<>();
 
         File storageDir = new File("/storage");
-        String internalStoragePath = Environment.getExternalStorageDirectory().getAbsolutePath();
+        String internalStoragePath =  mConfig.getPredefinedPath() != null ? mConfig.getPredefinedPath() : Environment.getExternalStorageDirectory().getAbsolutePath();
 
         File[] volumeList = storageDir.listFiles();
 


### PR DESCRIPTION
If no sdcard or getExternalStorageState() is not MEDIA_MOUNTED or MEDIA_MOUNTED_READ_ONLY, the application will be crashed by storage path, and not use the PredefinedPath.