### PR TITLE
Allow hiding of free space label

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can have the following configuration of builder.
 | withActivity | Activity  | Yes |
 | withFragmentManager | FragmentManager _(legacy)_ | Yes |
 | withMemoryBar | boolean | No |
-| withoutFreeSpaceLabel | boolean | No |
+| hideFreeSpaceLabel | boolean | No |
 | withPreference | SharedPreferences | actionSave(true) |
 | withPredefinedPath | String | No |
 | **setType** | StoragChooser.DIRECTORY_CHOOSER **_or_** StorageChooser.FILE_PICKER| allowCustomPath(true) |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can have the following configuration of builder.
 | withActivity | Activity  | Yes |
 | withFragmentManager | FragmentManager _(legacy)_ | Yes |
 | withMemoryBar | boolean | No |
+| withoutFreeSpaceLabel | boolean | No |
 | withPreference | SharedPreferences | actionSave(true) |
 | withPredefinedPath | String | No |
 | **setType** | StoragChooser.DIRECTORY_CHOOSER **_or_** StorageChooser.FILE_PICKER| allowCustomPath(true) |

--- a/app/src/main/java/com/codekidlabs/storagechooserdemo/MainActivity.java
+++ b/app/src/main/java/com/codekidlabs/storagechooserdemo/MainActivity.java
@@ -52,7 +52,7 @@ public class MainActivity extends AppCompatActivity {
         ((CheckBox) findViewById(R.id.checkbox_free_space_label)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                builder.withoutFreeSpaceLabel(isChecked);
+                builder.hideFreeSpaceLabel(isChecked);
             }
         });
 

--- a/app/src/main/java/com/codekidlabs/storagechooserdemo/MainActivity.java
+++ b/app/src/main/java/com/codekidlabs/storagechooserdemo/MainActivity.java
@@ -49,6 +49,13 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
+        ((CheckBox) findViewById(R.id.checkbox_free_space_label)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                builder.withoutFreeSpaceLabel(isChecked);
+            }
+        });
+
         ((CheckBox) findViewById(R.id.checkbox_add_folder)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,6 +37,14 @@
                     android:text="withMemoryBar" />
 
                 <CheckBox
+                    android:id="@+id/checkbox_free_space_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginTop="8dp"
+                    android:text="withoutFreeSpaceLabel" />
+
+                <CheckBox
                     android:id="@+id/checkbox_add_folder"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -42,7 +42,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"
                     android:layout_marginTop="8dp"
-                    android:text="withoutFreeSpaceLabel" />
+                    android:text="hideFreeSpaceLabel" />
 
                 <CheckBox
                     android:id="@+id/checkbox_add_folder"

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/StorageChooser.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/StorageChooser.java
@@ -226,7 +226,7 @@ public class StorageChooser {
             return this;
         }
 
-        public Builder withoutFreeSpaceLabel(boolean hideFreeSpaceLabel) {
+        public Builder hideFreeSpaceLabel(boolean hideFreeSpaceLabel) {
             mHideFreeSpaceLabel = hideFreeSpaceLabel;
             return this;
         }

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/StorageChooser.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/StorageChooser.java
@@ -190,6 +190,7 @@ public class StorageChooser {
         private Activity mActivity;
         private boolean mActionSave = false;
         private boolean mShowMemoryBar = false;
+        private boolean mHideFreeSpaceLabel = false;
         private boolean mAllowCustomPath = false;
         private boolean mAllowAddFolder = false;
         private boolean mShowHidden = false;
@@ -222,6 +223,11 @@ public class StorageChooser {
 
         public Builder withMemoryBar(boolean memoryBarBoolean) {
             mShowMemoryBar = memoryBarBoolean;
+            return this;
+        }
+
+        public Builder withoutFreeSpaceLabel(boolean hideFreeSpaceLabel) {
+            mHideFreeSpaceLabel = hideFreeSpaceLabel;
             return this;
         }
 
@@ -355,6 +361,7 @@ public class StorageChooser {
         public StorageChooser build() {
             devConfig.setActionSave(mActionSave);
             devConfig.setShowMemoryBar(mShowMemoryBar);
+            devConfig.setHideFreeSpaceLabel(mHideFreeSpaceLabel);
             devConfig.setAllowCustomPath(mAllowCustomPath);
             devConfig.setAllowAddFolder(mAllowAddFolder);
             devConfig.setShowHidden(mShowHidden);

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/adapters/StorageChooserListAdapter.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/adapters/StorageChooserListAdapter.java
@@ -13,7 +13,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.BaseAdapter;
-import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/adapters/StorageChooserListAdapter.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/adapters/StorageChooserListAdapter.java
@@ -7,11 +7,13 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.style.StyleSpan;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.BaseAdapter;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -35,6 +37,7 @@ public class StorageChooserListAdapter extends BaseAdapter {
     private List<Storages> storagesList;
     private Context mContext;
     private boolean shouldShowMemoryBar;
+    private boolean hideFreeSpaceLabel;
     private ProgressBar memoryBar;
     private int[] scheme;
     private float memorybarHeight;
@@ -44,12 +47,13 @@ public class StorageChooserListAdapter extends BaseAdapter {
 
 
     public StorageChooserListAdapter(List<Storages> storagesList, Context mContext,
-                                     boolean shouldShowMemoryBar, int[] scheme,
-                                     float memorybarHeight, String listTypeface, boolean fromAssets,
-                                     Content content) {
+                                     boolean shouldShowMemoryBar, boolean hideFreeSpaceLabel,
+                                     int[] scheme, float memorybarHeight, String listTypeface,
+                                     boolean fromAssets, Content content) {
         this.storagesList = storagesList;
         this.mContext = mContext;
         this.shouldShowMemoryBar = shouldShowMemoryBar;
+        this.hideFreeSpaceLabel = hideFreeSpaceLabel;
         this.scheme = scheme;
         this.memorybarHeight = memorybarHeight;
         this.listTypeface = listTypeface;
@@ -118,6 +122,11 @@ public class StorageChooserListAdapter extends BaseAdapter {
             runMemorybarAnimation(i);
         } else {
             memoryBar.setVisibility(View.GONE);
+        }
+
+        if (hideFreeSpaceLabel) {
+            memoryStatus.setVisibility(View.GONE);
+            storageName.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16);
         }
 
         return rootView;

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/fragments/ChooserDialogFragment.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/fragments/ChooserDialogFragment.java
@@ -114,8 +114,9 @@ public class ChooserDialogFragment extends android.app.DialogFragment {
         populateList();
 
         listView.setAdapter(new StorageChooserListAdapter(storagesList, context,
-                shouldShowMemoryBar, mConfig.getScheme(), mConfig.getMemorybarHeight(),
-                mConfig.getListFont(), mConfig.isListFromAssets(), mContent));
+                shouldShowMemoryBar, mConfig.isHideFreeSpaceLabel(), mConfig.getScheme(),
+                mConfig.getMemorybarHeight(), mConfig.getListFont(), mConfig.isListFromAssets(),
+                mContent));
 
 
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/storagechooser/src/main/java/com/codekidlabs/storagechooser/models/Config.java
+++ b/storagechooser/src/main/java/com/codekidlabs/storagechooser/models/Config.java
@@ -16,6 +16,7 @@ public class Config {
     private android.app.FragmentManager fragmentManager;
     private String predefinedPath;
     private boolean showMemoryBar;
+    private boolean hideFreeSpaceLabel;
     private float memorybarHeight;
     private boolean actionSave;
     private SharedPreferences preference;
@@ -71,6 +72,14 @@ public class Config {
 
     public void setShowMemoryBar(boolean showMemoryBar) {
         this.showMemoryBar = showMemoryBar;
+    }
+
+    public boolean isHideFreeSpaceLabel() {
+        return hideFreeSpaceLabel;
+    }
+
+    public void setHideFreeSpaceLabel(boolean hideFreeSpaceLabel) {
+        this.hideFreeSpaceLabel = hideFreeSpaceLabel;
     }
 
     public boolean isActionSave() {

--- a/storagechooser/src/main/res/layout/row_storage.xml
+++ b/storagechooser/src/main/res/layout/row_storage.xml
@@ -2,25 +2,19 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="16dp"
     android:orientation="vertical">
-
 
     <TextView
         android:id="@+id/storage_name"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp" />
+        android:layout_height="wrap_content" />
 
     <ProgressBar
         android:id="@+id/memory_bar"
         style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
         android:layout_marginTop="8dp" />
 
     <TextView
@@ -28,9 +22,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
         android:layout_marginTop="4dp"
         android:textColor="@color/colorPrimaryDark"
         android:textSize="13sp" />


### PR DESCRIPTION
Adds a withoutFreeSpaceLabel(boolean) method to the Builder class.
Note that this increases the storage name labels size if the free space
label is hidden and that the layout margins are a bit different now.