### PR TITLE
Add FindBugs support

### DIFF
--- a/storagechooser/build.gradle
+++ b/storagechooser/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'findbugs'
+
+findbugs {
+    sourceSets = []
+    ignoreFailures = false
+}
 
 group = 'com.github.codekidX'
 
@@ -51,4 +57,23 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 artifacts {
     archives javadocJar
+}
+
+task findbugs(type: FindBugs, dependsOn: 'assembleDebug') {
+
+    description 'Run findbugs'
+    group 'verification'
+
+    classes = fileTree('build/intermediates/classes/debug/')
+    source = fileTree('src/main/java')
+    classpath = files()
+
+    effort = 'max'
+
+    excludeFilter = file("./config/findbugs/exclude.xml")
+
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
 }

--- a/storagechooser/config/findbugs/exclude.xml
+++ b/storagechooser/config/findbugs/exclude.xml
@@ -1,0 +1,10 @@
+<FindBugsFilter>
+
+    <Match>
+        <Class name="~.*R\$.*"/>
+    </Match>
+    <Match>
+        <Class name="~.*Manifest\$.*"/>
+    </Match>
+
+</FindBugsFilter>


### PR DESCRIPTION
This adds support for the [FindBugs](http://findbugs.sourceforge.net/) java static analysis tool. It will scan the java source of the Android project and determine if any known bugs exist. To run this tool, use the following:

$ ./gradlew findbugs

It will output a HTML report with its findings. As of this writing, a few issues are identified. A sample report is attached here: [findbugs.html.zip](https://github.com/codekidX/storage-chooser/files/2173830/findbugs.html.zip)

If an issue is found and you want to ignore it, you can add exclusions to the exclude.xml file; a base file is included.

I've used this tool in my Android projects. I'm submitting this request, in case it may be useful to you as well. (: